### PR TITLE
enable support for decoupled in-car settings

### DIFF
--- a/DataPluginDemo.cs
+++ b/DataPluginDemo.cs
@@ -75,7 +75,7 @@ namespace User.PluginSdkDemo
 
         int counter = 0;
 
-        bool isInPitMenu = false;
+        bool pitMenuRequirementMet = false;
 
         int roadOff = 0;
         bool outLap = false;
@@ -393,7 +393,7 @@ namespace User.PluginSdkDemo
         bool NBvalue = false;
 
         int fuelSaveDelta = 0;
-        bool plussButtonCheck = false;
+        bool plusButtonCheck = false;
         bool minusButtonCheck = false;
         bool OKButtonCheck = false;
         bool upshift = false;
@@ -540,6 +540,7 @@ namespace User.PluginSdkDemo
                 pluginManager.SetPropertyValue("ARBstiffForward", this.GetType(), Settings.SupercarARBDirection);
                 pluginManager.SetPropertyValue("SmallFuelIncrement", this.GetType(), Settings.SmallFuelIncrement);
                 pluginManager.SetPropertyValue("LargeFuelIncrement", this.GetType(), Settings.LargeFuelIncrement);
+                pluginManager.SetPropertyValue("CoupleInCarToPit", this.GetType(), Settings.CoupleInCarToPit);
             }
 
 
@@ -1467,7 +1468,7 @@ namespace User.PluginSdkDemo
                 //-------SHIFT LIGHT/SHIFT POINT PER GEAR-------
                 //----------------------------------------------
 
-                
+
 
                 switch (gear)
                 {
@@ -1934,13 +1935,20 @@ namespace User.PluginSdkDemo
                 //----------------------------------------------------
 
                 //Pit commands
-                if (inCarRotary == 0 && pitMenuRotary != 0 || rotaryType == "Single" || (rotaryType != "Single" && rotaryType != "Default" && inCarRotary == 12))
+                if (!Settings.CoupleInCarToPit) // Ignore all of this if we explicitly state that coupling the InCar to Pit is off in settings)
                 {
-                    isInPitMenu = true;
+                    pitMenuRequirementMet = true;
+                }
+                else if (
+                    inCarRotary == 0 && pitMenuRotary != 0 || 
+                    rotaryType == "Single" ||
+                    (rotaryType != "Single" && rotaryType != "Default" && inCarRotary == 12))
+                {
+                    pitMenuRequirementMet = true;
                 }
                 else
                 {
-                    isInPitMenu = false;
+                    pitMenuRequirementMet = false;
                 }
 
                 bool aheadPlayerReady = false;
@@ -1960,9 +1968,9 @@ namespace User.PluginSdkDemo
                     pitMenuRotary = inCarRotary;
                 }
 
-                if (plussButtonCheck)
+                if (plusButtonCheck)
                 {
-                    if (pitMenuRotary == 1 && isInPitMenu)
+                    if (pitMenuRotary == 1 && pitMenuRequirementMet)
                     {
                         string pushPit = "";
 
@@ -1977,15 +1985,15 @@ namespace User.PluginSdkDemo
 
                         PitCommands.iRacingChat(pushPit);
                     }
-                    else if (pitMenuRotary == 2 && isInPitMenu)
+                    else if (pitMenuRotary == 2 && pitMenuRequirementMet)
                     {
                         launchActive = !launchActive;
                     }
-                    else if (pitMenuRotary == 3 && isInPitMenu)
+                    else if (pitMenuRotary == 3 && pitMenuRequirementMet)
                     {
                         PitCommands.iRacingChat("#lf +3kpa rf +3kpa lr +3kpa rr +3kpa$");
                     }
-                    else if (pitMenuRotary == 4 && isInPitMenu)
+                    else if (pitMenuRotary == 4 && pitMenuRequirementMet)
                     {
                         if (pitCrewType < CrewType.LeftRight || pitCrewType == CrewType.All)
                         {
@@ -1996,7 +2004,7 @@ namespace User.PluginSdkDemo
                             PitCommands.iRacingChat("#lf +3kpa lr +3kpa$");
                         }
                     }
-                    else if (pitMenuRotary == 5 && isInPitMenu)
+                    else if (pitMenuRotary == 5 && pitMenuRequirementMet)
                     {
                         if (pitCrewType < CrewType.LeftRight || pitCrewType == CrewType.All)
                         {
@@ -2007,47 +2015,47 @@ namespace User.PluginSdkDemo
                             PitCommands.iRacingChat("#rf +3kpa rr +3kpa$");
                         }
                     }
-                    else if (pitMenuRotary == 6 && isInPitMenu && aheadPlayerReady)
+                    else if (pitMenuRotary == 6 && pitMenuRequirementMet && aheadPlayerReady)
                     {
                         PitCommands.iRacingChat("/" + data.NewData.OpponentsAheadOnTrack[0].CarNumber + " " + Settings.AheadPlayerText);
                     }
-                    else if (pitMenuRotary == 7 && isInPitMenu)
+                    else if (pitMenuRotary == 7 && pitMenuRequirementMet)
                     {
                         PitCommands.iRacingChat("#fuel +" + Settings.SmallFuelIncrement + "l$");
                     }
-                    else if (pitMenuRotary == 8 && isInPitMenu)
+                    else if (pitMenuRotary == 8 && pitMenuRequirementMet)
                     {
                         PitCommands.iRacingChat("#fuel +" + Settings.LargeFuelIncrement + "l$");
                     }
-                    else if (pitMenuRotary == 9 && isInPitMenu)
+                    else if (pitMenuRotary == 9 && pitMenuRequirementMet)
                     {
                         watchSplit = true;
                     }
 
-                    else if (pitMenuRotary == 10 && isInPitMenu)
+                    else if (pitMenuRotary == 10 && pitMenuRequirementMet)
                     {
                         pluginManager.TriggerAction("DataCorePlugin.IncrementSystemVolume");
                     }
 
-                    else if (pitMenuRotary == 11 && isInPitMenu)
+                    else if (pitMenuRotary == 11 && pitMenuRequirementMet)
                     {
                         savePitTimerLock = true;
                         savePitTimerSnap = slowestLapTimeSpanCopy;
                     }
 
-                    else if (pitMenuRotary == 12 && isInPitMenu)
+                    else if (pitMenuRotary == 12 && pitMenuRequirementMet)
                     {
                         //pluginManager.TriggerAction("ShakeITBSV3Plugin.MainFeedbackLevelIncrement");
                         fuelPerLapOffset = fuelPerLapOffset + Settings.fuelOffsetIncrement;
                     }
 
 
-                    plussButtonCheck = false;
+                    plusButtonCheck = false;
                 }
 
                 if (minusButtonCheck)
                 {
-                    if (pitMenuRotary == 1 && isInPitMenu)
+                    if (pitMenuRotary == 1 && pitMenuRequirementMet)
                     {
                         string pushPit = "";
                         if (commandMinFuel == 0)
@@ -2060,15 +2068,15 @@ namespace User.PluginSdkDemo
                         }
                         PitCommands.iRacingChat(pushPit);
                     }
-                    else if (pitMenuRotary == 2 && isInPitMenu)
+                    else if (pitMenuRotary == 2 && pitMenuRequirementMet)
                     {
                         paceCheck = !paceCheck;
                     }
-                    else if (pitMenuRotary == 3 && isInPitMenu)
+                    else if (pitMenuRotary == 3 && pitMenuRequirementMet)
                     {
                         PitCommands.iRacingChat("#lf -3kpa rf -3kpa lr -3kpa rr -3kpa$");
                     }
-                    else if (pitMenuRotary == 4 && isInPitMenu)
+                    else if (pitMenuRotary == 4 && pitMenuRequirementMet)
                     {
                         if (pitCrewType < CrewType.LeftRight || pitCrewType == CrewType.All)
                         {
@@ -2079,7 +2087,7 @@ namespace User.PluginSdkDemo
                             PitCommands.iRacingChat("#lf -3kpa lr -3kpa$");
                         }
                     }
-                    else if (pitMenuRotary == 5 && isInPitMenu)
+                    else if (pitMenuRotary == 5 && pitMenuRequirementMet)
                     {
                         if (pitCrewType < CrewType.LeftRight || pitCrewType == CrewType.All)
                         {
@@ -2090,21 +2098,21 @@ namespace User.PluginSdkDemo
                             PitCommands.iRacingChat("#rf -3kpa rr -3kpa$");
                         }
                     }
-                    else if (pitMenuRotary == 6 && isInPitMenu && behindPlayerReady)
+                    else if (pitMenuRotary == 6 && pitMenuRequirementMet && behindPlayerReady)
                     {
                         string driverText = "/#" + data.NewData.OpponentsBehindOnTrack[0].CarNumber + " " + Settings.BehindPlayerText;
                         PitCommands.iRacingChat(driverText);
                     }
-                    else if (pitMenuRotary == 7 && isInPitMenu)
+                    else if (pitMenuRotary == 7 && pitMenuRequirementMet)
                     {
                         PitCommands.iRacingChat("#fuel -" + Settings.SmallFuelIncrement + "l$");
                     }
-                    else if (pitMenuRotary == 8 && isInPitMenu)
+                    else if (pitMenuRotary == 8 && pitMenuRequirementMet)
                     {
                         PitCommands.iRacingChat("#fuel -" + Settings.LargeFuelIncrement + "l$");
                     }
 
-                    else if (pitMenuRotary == 9 && isInPitMenu)
+                    else if (pitMenuRotary == 9 && pitMenuRequirementMet)
                     {
                         watchTimer = globalClock;
                         watchSnap = 0;
@@ -2113,18 +2121,18 @@ namespace User.PluginSdkDemo
                         watchSplit = false;
                     }
 
-                    else if (pitMenuRotary == 10 && isInPitMenu)
+                    else if (pitMenuRotary == 10 && pitMenuRequirementMet)
                     {
                         pluginManager.TriggerAction("DataCorePlugin.DecrementSystemVolume");
 
                     }
 
-                    else if (pitMenuRotary == 11 && isInPitMenu)
+                    else if (pitMenuRotary == 11 && pitMenuRequirementMet)
                     {
                         savePitTimerLock = false;
                     }
 
-                    else if (pitMenuRotary == 12 && isInPitMenu)
+                    else if (pitMenuRotary == 12 && pitMenuRequirementMet)
                     {
                         //pluginManager.TriggerAction("ShakeITBSV3Plugin.MainFeedbackLevelDecrement");
                         if ((fuelAvgLap + fuelPerLapOffset - Settings.fuelOffsetIncrement) > 0)
@@ -2142,20 +2150,20 @@ namespace User.PluginSdkDemo
 
                 if (OKButtonCheck)
                 {
-                    if (pitMenuRotary == 1 && isInPitMenu)
+                    if (pitMenuRotary == 1 && pitMenuRequirementMet)
                     {
                         PitCommands.iRacingChat("#clear$");
                         fuelPerLapOffset = 0;
                     }
-                    else if (pitMenuRotary == 2 && isInPitMenu)
+                    else if (pitMenuRotary == 2 && pitMenuRequirementMet)
                     {
                         PitCommands.iRacingChat("#!fr$");
                     }
-                    else if (pitMenuRotary == 3 && isInPitMenu)
+                    else if (pitMenuRotary == 3 && pitMenuRequirementMet)
                     {
                         PitCommands.iRacingChat("#!cleartires$");
                     }
-                    else if (pitMenuRotary == 4 && isInPitMenu)
+                    else if (pitMenuRotary == 4 && pitMenuRequirementMet)
                     {
                         if (pitCrewType < CrewType.LeftRight)
                         {
@@ -2170,7 +2178,7 @@ namespace User.PluginSdkDemo
                             PitCommands.iRacingChat("#!cleartires$");
                         }
                     }
-                    else if (pitMenuRotary == 5 && isInPitMenu)
+                    else if (pitMenuRotary == 5 && pitMenuRequirementMet)
                     {
                         if (pitCrewType < CrewType.LeftRight)
                         {
@@ -2185,27 +2193,27 @@ namespace User.PluginSdkDemo
                             PitCommands.iRacingChat("#!cleartires$");
                         }
                     }
-                    else if (pitMenuRotary == 6 && isInPitMenu)
+                    else if (pitMenuRotary == 6 && pitMenuRequirementMet)
                     {
                         PitCommands.iRacingChat("#!ws$");
                     }
-                    else if (pitMenuRotary == 7 && isInPitMenu)
+                    else if (pitMenuRotary == 7 && pitMenuRequirementMet)
                     {
                         PitCommands.iRacingChat("#!fuel$");
                     }
-                    else if (pitMenuRotary == 8 && isInPitMenu)
+                    else if (pitMenuRotary == 8 && pitMenuRequirementMet)
                     {
                         pitActive = !pitActive;
                     }
-                    else if (pitMenuRotary == 9 && isInPitMenu)
+                    else if (pitMenuRotary == 9 && pitMenuRequirementMet)
                     {
                         watchOn = !watchOn;
                     }
-                    else if (pitMenuRotary == 10 && isInPitMenu)
+                    else if (pitMenuRotary == 10 && pitMenuRequirementMet)
                     {
                         spotMode = !spotMode;
                     }
-                    else if (pitMenuRotary == 11 && isInPitMenu)
+                    else if (pitMenuRotary == 11 && pitMenuRequirementMet)
                     {
                         fuelSaveDelta++;
                         if (fuelSaveDelta > 4)
@@ -2213,7 +2221,7 @@ namespace User.PluginSdkDemo
                             fuelSaveDelta = 0;
                         }
                     }
-                    else if (pitMenuRotary == 12 && isInPitMenu)
+                    else if (pitMenuRotary == 12 && pitMenuRequirementMet)
                     {
                         Settings.fuelPerLapTarget = fuelAvgLap + fuelPerLapOffset;
                     }
@@ -6356,7 +6364,7 @@ namespace User.PluginSdkDemo
 
             //Update property
 
-            pluginManager.AddProperty("Version", this.GetType(), "1.8.0");
+            pluginManager.AddProperty("Version", this.GetType(), "1.8.1");
 
             //Key presses
             pluginManager.AddProperty("FuelSaveDelta", this.GetType(), 0);
@@ -6374,9 +6382,9 @@ namespace User.PluginSdkDemo
             pluginManager.AddProperty("LEDWarnings", this.GetType(), false);
             pluginManager.AddProperty("SpotterMode", this.GetType(), false);
 
-            pluginManager.AddAction("PlussPressed", this.GetType(), (a, b) =>
+            pluginManager.AddAction("PlusPressed", this.GetType(), (a, b) =>
             {
-                plussButtonCheck = true;
+                plusButtonCheck = true;
             });
 
             pluginManager.AddAction("MinusPressed", this.GetType(), (a, b) =>
@@ -6923,6 +6931,7 @@ namespace User.PluginSdkDemo
             pluginManager.AddProperty("ARBstiffForward", this.GetType(), Settings.SupercarARBDirection);
             pluginManager.AddProperty("SmallFuelIncrement", this.GetType(), Settings.SmallFuelIncrement);
             pluginManager.AddProperty("LargeFuelIncrement", this.GetType(), Settings.LargeFuelIncrement);
+            pluginManager.AddProperty("CoupleInCarToPit", this.GetType(), Settings.CoupleInCarToPit);
 
             pluginManager.AddProperty("Idle", this.GetType(), true);
             pluginManager.AddProperty("SmoothGear", this.GetType(), "");

--- a/DataPluginDemoSettings.cs
+++ b/DataPluginDemoSettings.cs
@@ -23,6 +23,9 @@ namespace User.PluginSdkDemo
 
         public int SmallFuelIncrement { get; set; } = 2; //In Liters
         public int LargeFuelIncrement { get; set; } = 10; //In Liters
+
+        public bool CoupleInCarToPit { get; set; } = true; //Only allow pit commands when the in-car rotary is on Pit Mode.
+
         public bool ShiftTimingAssist { get; set; } = false;
 
         public string AheadPlayerText { get; set; } = "Blue flag";

--- a/SettingsControlDemo.xaml
+++ b/SettingsControlDemo.xaml
@@ -6,10 +6,10 @@
              xmlns:local="clr-namespace:User.PluginSdkDemo"
              xmlns:styles="clr-namespace:SimHub.Plugins.Styles;assembly=SimHub.Plugins" mc:Ignorable="d" 
              xmlns:ui="clr-namespace:SimHub.Plugins.UI;assembly=SimHub.Plugins"
-             d:DesignHeight="1200" Width="820" HorizontalAlignment="Left">
+             d:DesignHeight="1080" Width="820" HorizontalAlignment="Left">
 
     <Grid>
-        <TabControl HorizontalAlignment="Left" Height="1155" VerticalAlignment="Top" Width="820 " Margin="0,12,0,0">
+        <TabControl HorizontalAlignment="Left" Height="1080" VerticalAlignment="Top" Width="820 " Margin="0,12,0,0">
             <TabItem Header="PIT ROTARY" Foreground="#FF252525">
                 <Grid Background="#FFDADADA" Margin="0,0,0,0">
                     <ScrollViewer>
@@ -65,9 +65,9 @@
                             <StackPanel>
                                 <ui:ControlsEditor FriendlyName="Upshift (pressed)" ActionName="DahlDesign.Upshift" HorizontalAlignment="Left" Width="750"/>
                                 <ui:ControlsEditor FriendlyName="Downshift (pressed)" ActionName="DahlDesign.Downshift" HorizontalAlignment="Left" Width="750"/>
-                                <ui:ControlsEditor FriendlyName="Menu: +" ActionName="DahlDesign.PlussPressed" Margin="0,0,-240,0" HorizontalAlignment="Left" Width="750"/>
-                                <ui:ControlsEditor FriendlyName="Menu: -" ActionName="DahlDesign.MinusPressed" Margin="0,0,-240,0" HorizontalAlignment="Left" Width="750"/>
-                                <ui:ControlsEditor FriendlyName="Menu: OK" ActionName="DahlDesign.OKPressed" Margin="0,0,-240,0" HorizontalAlignment="Left" Width="750"/>
+                                <ui:ControlsEditor FriendlyName="Pit Menu: +" ActionName="DahlDesign.PlusPressed" Margin="0,0,-240,0" HorizontalAlignment="Left" Width="750"/>
+                                <ui:ControlsEditor FriendlyName="Pit Menu: -" ActionName="DahlDesign.MinusPressed" Margin="0,0,-240,0" HorizontalAlignment="Left" Width="750"/>
+                                <ui:ControlsEditor FriendlyName="Pit Menu: OK" ActionName="DahlDesign.OKPressed" Margin="0,0,-240,0" HorizontalAlignment="Left" Width="750"/>
                                 <ui:ControlsEditor FriendlyName="TC Off (pressed)" ActionName="DahlDesign.TCPressed"  HorizontalAlignment="Left" Width="750"/>
                                 <ui:ControlsEditor FriendlyName="TC Off (released)" ActionName="DahlDesign.TCReleased" HorizontalAlignment="Left" Width="750"/>
                                 <ui:ControlsEditor FriendlyName="ERS No Boost" ActionName="DahlDesign.NBPressed" Margin="0,0,-240,0" HorizontalAlignment="Left" Width="750"/>
@@ -314,6 +314,13 @@
                                 VerticalAlignment="Top"
                                 Height="20"
                                 IsChecked="{Binding LapInfoScreen}" Margin="14,-20,0,10"/>
+                            <TextBlock
+                                Text="Couple Pit Controls Enable to In-Car Rotary - Support mode fual dual 12-position switches" Margin="10,0,0,23"/>
+                            <styles:SHToggleButton
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Top"
+                                Height="20"
+                                IsChecked="{Binding CoupleInCarToPit}" Margin="14,-20,0,10"/>
                             <TextBlock
                                 Text="Activate wheel slip functions:" Margin="10,0,0,23"/>
                             <styles:SHToggleButton

--- a/SettingsControlDemo.xaml
+++ b/SettingsControlDemo.xaml
@@ -201,9 +201,9 @@
                 </Grid>
             </TabItem>
             <TabItem Header="DDC" Margin="3,0,-3,0" BorderBrush="#CC1BA1DA" Foreground="#FF252525">
-                <Grid Background="#FFDADADA" Margin="0,0,0,0">
+                <Grid Background="#FFDADADA" Margin="0,0,0,0" Width="806">
                     <styles:SHSection Title="Dahl Design Controller" Margin="0,0,0,0">
-                        <StackPanel>
+                        <StackPanel Margin="0,0,9,0">
                             <TextBlock
                                     Text="Name of your joystick controller. &quot;JoystickPlugin.Arduino_Leonardo_B01&quot; means you write &quot;Arduino_Leonardo&quot; here." Grid.Row="1" Margin="10,25,0,23" Grid.RowSpan="2"/>
                             <TextBox
@@ -211,37 +211,15 @@
                                     Height="20"  
                                     Margin="10,-20,0,10"                        
                                     Text="{Binding DDC}"/>
+
+                            <TextBlock Grid.Row="0" Text="DDC Enabled"/>
+                            <styles:SHToggleButton  Grid.Row="0" HorizontalAlignment="Left" VerticalAlignment="Top" Height="20" IsChecked="{Binding Path=DDCEnabled}"/>
+                            <TextBlock Grid.Row="0" Text="DDS Enabled" />
+                            <styles:SHToggleButton  Grid.Row="0" HorizontalAlignment="Left" VerticalAlignment="Top" Height="20" IsChecked="{Binding DDSEnabled}"/>
+                            <TextBlock Grid.Row="0" Text="DDC Clutch"/>
+                            <styles:SHToggleButton Grid.Row="0" HorizontalAlignment="Left" VerticalAlignment="Top" Height="20" IsChecked="{Binding DDCclutchEnabled}"/>
                         </StackPanel>
                     </styles:SHSection>
-
-                    <TextBlock
-                        Grid.Row="0"
-                        Text="DDC Enabled" Margin="32,127,-32,895"/>
-                    <styles:SHToggleButton  
-                        Grid.Row="0"
-                        HorizontalAlignment="Left"
-                        VerticalAlignment="Top"
-                        Height="20"
-                        IsChecked="{Binding Path=DDCEnabled}" Margin="115,126,0,0"/>
-                    <TextBlock
-                        Grid.Row="0"
-                        Text="DDS Enabled" Margin="32,166,-32,856"/>
-                    <styles:SHToggleButton  
-                        Grid.Row="0"
-                        HorizontalAlignment="Left"
-                        VerticalAlignment="Top"
-                        Height="20"
-                        IsChecked="{Binding DDSEnabled}" Margin="115,165,0,0"/>
-                    <TextBlock
-                        Grid.Row="0"
-                        Text="DDC
- Clutch" Margin="32,204,-32,818"/>
-                    <styles:SHToggleButton  
-                        Grid.Row="0"
-                        HorizontalAlignment="Left"
-                        VerticalAlignment="Top"
-                        Height="20"
-                        IsChecked="{Binding DDCclutchEnabled}" Margin="115,203,0,0"/>
                 </Grid>
             </TabItem>
             <TabItem Header="MISC" Margin="3,0,-3,0" BorderBrush="#CC1BA1DA" Foreground="#FF252525">

--- a/SettingsControlDemo.xaml
+++ b/SettingsControlDemo.xaml
@@ -293,7 +293,7 @@
                                 Height="20"
                                 IsChecked="{Binding LapInfoScreen}" Margin="14,-20,0,10"/>
                             <TextBlock
-                                Text="Couple Pit Controls Enable to In-Car Rotary - Support mode fual dual 12-position switches" Margin="10,0,0,23"/>
+                                Text="Disable PitMenu Controls unless In-Car Rotary unused or in 12th/Pit position" Margin="10,0,0,23"/>
                             <styles:SHToggleButton
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Top"

--- a/User.PluginSdkDemo.csproj
+++ b/User.PluginSdkDemo.csproj
@@ -34,10 +34,12 @@
     <Reference Include="ACSharedMemory, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\ACSharedMemory.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="ACToolsUtilities, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\ACToolsUtilities.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="CsvHelper, Version=29.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
       <HintPath>packages\CsvHelper.29.0.0\lib\net47\CsvHelper.dll</HintPath>
@@ -49,14 +51,17 @@
     <Reference Include="ICarsReader, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\ICarsReader.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="InputManagerCS, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\InputManagerCS.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="iRacingSDK, Version=1.0.7896.30708, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\iRacingSDK.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -88,21 +93,26 @@
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Memory.4.5.0\lib\netstandard2.0\System.Memory.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Threading.Tasks.Extensions.4.5.2\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />


### PR DESCRIPTION
Adds a toggle for decoupling the in car option position from the pit option enablement.  Defaults to "coupled" to match previous behavior.  

When disabled, it allows pit menu actions even if the in car rotary is not set to "put". 

(also fixed a spelling error and some build options).  

Follow up PR coming to change the InCar menu "pit" option to "-" when coupling is disabled.  

Fixes #1 