### PR TITLE
Added session specific dash choices

### DIFF
--- a/DahlDesign.Plugin.csproj
+++ b/DahlDesign.Plugin.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>$(ProgramFiles)\SimHub\</OutputPath>
+    <OutputPath>..\..\</OutputPath>
     <!--OutputPath>bin\Debug\</OutputPath-->
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>

--- a/DataPluginSettings.cs
+++ b/DataPluginSettings.cs
@@ -52,8 +52,15 @@ namespace DahlDesign.Plugin
         public bool ShowMapEnabled { get; set; } = false;
         public bool ShowBrakeThrottleGaugesEnabled { get; set; } = false;
         public string DashType { get; set; } = "Automatic Selection";
-        public string LeftScreen { get; set; } = "Time Attack";
-        public string RightScreen { get; set; } = "Practice";
+        public string LeftScreen { get; set; } = "Time1";
+        public string RightScreen { get; set; } = "Stint1";
+        public string LeftPracticeScreen { get; set; } = "None";
+        public string RightPracticeScreen { get; set; } = "None";
+        public string LeftQualyScreen { get; set; } = "None";
+        public string RightQualyScreen { get; set; } = "None";
+        public string LeftRaceScreen { get; set; } = "None";
+        public string RightRaceScreen { get; set; } = "None";
+
 
         #region Property supporting UI refresh from code
         /*

--- a/Sections/Dashboard.cs
+++ b/Sections/Dashboard.cs
@@ -34,16 +34,6 @@ namespace DahlDesign.Plugin.Categories
             Base.AddProp("MenuType", "");
             Base.AddProp("Dashboard.LeftScreen", Base.Settings.LeftScreen);
             Base.AddProp("Dashboard.RightScreen", Base.Settings.RightScreen);
-            try
-            {
-                LeftScreen.screenID = System.Convert.ToInt32(Base.Settings.LeftScreen);              //setup left startup screen      
-            }
-            catch (System.Exception) { }
-            try
-            {
-                RightScreen.screenID = System.Convert.ToInt32(Base.Settings.RightScreen);            //setup right startup screen 
-            }
-            catch (System.Exception) { }
 
             Base.AddAction(
                 "Controls.MapToggle",
@@ -84,47 +74,29 @@ namespace DahlDesign.Plugin.Categories
             Base.SetProp("ShowMapEnabled", Base.Settings.ShowMapEnabled);
             Base.SetProp("ShowBrakeThrottleGaugesEnabled", Base.Settings.ShowBrakeThrottleGaugesEnabled);
 
-            Base.SetProp("Dashboard.LeftScreen", LeftScreen.screenID);
-            Base.SetProp("Dashboard.RightScreen", RightScreen.screenID);
-
             string session = Base.gameData.NewData.SessionTypeName;
 
             if (Base.iRacing.sessionHolder != session)
             {
-                if (session == "Practice" || session == "Warmup")
+                if (session == "Practice" || session == "Warmup" || session == "Offline testing")
                 {
-                    if (Base.Settings.LeftPracticeScreen != "None")
-                    {
-                        LeftScreen.screenID = System.Convert.ToInt32(Base.Settings.LeftPracticeScreen);
-                    }
-                    if (Base.Settings.RightPracticeScreen != "None")
-                    {
-                        RightScreen.screenID = System.Convert.ToInt32(Base.Settings.RightPracticeScreen);
-                    }
+                     LeftScreen.screenID = System.Convert.ToInt32(Base.Settings.LeftPracticeScreen);
+                     RightScreen.screenID = System.Convert.ToInt32(Base.Settings.RightPracticeScreen);
                 }
                 else if (session == "Race")
                 {
-                    if (Base.Settings.LeftRaceScreen != "None")
-                    {
-                        LeftScreen.screenID = System.Convert.ToInt32(Base.Settings.LeftRaceScreen);
-                    }
-                    if (Base.Settings.RightRaceScreen != "None")
-                    {
-                        RightScreen.screenID = System.Convert.ToInt32(Base.Settings.RightRaceScreen);
-                    }
+                    LeftScreen.screenID = System.Convert.ToInt32(Base.Settings.LeftRaceScreen);
+                    RightScreen.screenID = System.Convert.ToInt32(Base.Settings.RightRaceScreen);
                 }
                 else if (session == "Lone Qualify" || session == "Open Qualify")
                 {
-                    if (Base.Settings.LeftQualyScreen != "None")
-                    {
-                        LeftScreen.screenID = System.Convert.ToInt32(Base.Settings.LeftQualyScreen);
-                    }
-                    if (Base.Settings.RightQualyScreen != "None")
-                    {
-                        RightScreen.screenID = System.Convert.ToInt32(Base.Settings.RightQualyScreen);
-                    }
+                    LeftScreen.screenID = System.Convert.ToInt32(Base.Settings.LeftQualyScreen);
+                    RightScreen.screenID = System.Convert.ToInt32(Base.Settings.RightQualyScreen);
                 }
             }
+
+            Base.SetProp("Dashboard.LeftScreen", LeftScreen.screenID);
+            Base.SetProp("Dashboard.RightScreen", RightScreen.screenID);
 
             if (Base.counter != 2)
                 return;

--- a/Sections/Dashboard.cs
+++ b/Sections/Dashboard.cs
@@ -9,6 +9,9 @@ namespace DahlDesign.Plugin.Categories
 
         public Screen LeftScreen;
         public Screen RightScreen;
+
+       
+
         public Dashboard(DahlDesign dahlDesign)
         {
             Base = dahlDesign;
@@ -84,10 +87,48 @@ namespace DahlDesign.Plugin.Categories
             Base.SetProp("Dashboard.LeftScreen", LeftScreen.screenID);
             Base.SetProp("Dashboard.RightScreen", RightScreen.screenID);
 
+            string session = Base.gameData.NewData.SessionTypeName;
+
+            if (Base.iRacing.sessionHolder != session)
+            {
+                if (session == "Practice" || session == "Warmup")
+                {
+                    if (Base.Settings.LeftPracticeScreen != "None")
+                    {
+                        LeftScreen.screenID = System.Convert.ToInt32(Base.Settings.LeftPracticeScreen);
+                    }
+                    if (Base.Settings.RightPracticeScreen != "None")
+                    {
+                        RightScreen.screenID = System.Convert.ToInt32(Base.Settings.RightPracticeScreen);
+                    }
+                }
+                else if (session == "Race")
+                {
+                    if (Base.Settings.LeftRaceScreen != "None")
+                    {
+                        LeftScreen.screenID = System.Convert.ToInt32(Base.Settings.LeftRaceScreen);
+                    }
+                    if (Base.Settings.RightRaceScreen != "None")
+                    {
+                        RightScreen.screenID = System.Convert.ToInt32(Base.Settings.RightRaceScreen);
+                    }
+                }
+                else if (session == "Lone Qualify" || session == "Open Qualify")
+                {
+                    if (Base.Settings.LeftQualyScreen != "None")
+                    {
+                        LeftScreen.screenID = System.Convert.ToInt32(Base.Settings.LeftQualyScreen);
+                    }
+                    if (Base.Settings.RightQualyScreen != "None")
+                    {
+                        RightScreen.screenID = System.Convert.ToInt32(Base.Settings.RightQualyScreen);
+                    }
+                }
+            }
+
             if (Base.counter != 2)
                 return;
-
-
+            
             Base.SetProp("DDUstartLED", Base.Settings.DDUstartLED);
             Base.SetProp("SW1startLED", Base.Settings.SW1startLED);
             Base.SetProp("DDUEnabled", Base.Settings.DDUEnabled);

--- a/Sections/Dashboard.cs
+++ b/Sections/Dashboard.cs
@@ -71,6 +71,8 @@ namespace DahlDesign.Plugin.Categories
 
         public void DataUpdate()
         {
+            if (Base.gameName != "IRacing" || !Base.gameRunning) return;
+        
             Base.SetProp("ShowMapEnabled", Base.Settings.ShowMapEnabled);
             Base.SetProp("ShowBrakeThrottleGaugesEnabled", Base.Settings.ShowBrakeThrottleGaugesEnabled);
 

--- a/SettingsControl.xaml
+++ b/SettingsControl.xaml
@@ -439,9 +439,9 @@
                             Height="20"
                             IsChecked="{Binding ShowBrakeThrottleGaugesEnabled}" RenderTransformOrigin="0.45,0.2"/>
 
-                            <TextBlock Grid.Row="4" Text="Left Screen at startup"/>
-                                <ComboBox Grid.Row="4" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
-                                          SelectedValuePath="Tag" SelectedValue="{Binding LeftScreen}">
+                            <TextBlock Grid.Row="4" Text="Left Screen in practice"/>
+                            <ComboBox Grid.Row="4" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
+                                SelectedValuePath="Tag" SelectedValue="{Binding LeftPracticeScreen}">
                                 <ComboBoxItem Tag="1" IsSelected="True">Time1</ComboBoxItem>
                                 <ComboBoxItem Tag="2">Time2</ComboBoxItem>
                                 <ComboBoxItem Tag="3">Time3</ComboBoxItem>
@@ -453,9 +453,9 @@
                                 <ComboBoxItem Tag="9">Practice2</ComboBoxItem>
                             </ComboBox>
 
-                            <TextBlock Grid.Row="5" Text="Right Screen at startup"/>
-                                <ComboBox Grid.Row="5" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
-                                          SelectedValuePath="Tag" SelectedValue="{Binding RightScreen}">
+                                <TextBlock Grid.Row="5" Text="Right Screen in practice"/>
+                            <ComboBox Grid.Row="5" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
+                                    SelectedValuePath="Tag" SelectedValue="{Binding RightPracticeScreen}">
                                 <ComboBoxItem Tag="1" IsSelected="True">Stint1</ComboBoxItem>
                                 <ComboBoxItem Tag="2">Stint2</ComboBoxItem>
                                 <ComboBoxItem Tag="3">Qualy1</ComboBoxItem>
@@ -463,94 +463,61 @@
                                 <ComboBoxItem Tag="5">Race1</ComboBoxItem>
                                 <ComboBoxItem Tag="6">Race2</ComboBoxItem>
                                 <ComboBoxItem Tag="7">Race3</ComboBoxItem>
-                                <ComboBoxItem Tag="8">Track</ComboBoxItem>                                
+                                <ComboBoxItem Tag="8">Track</ComboBoxItem>
                             </ComboBox>
 
-                            <TextBlock Grid.Row="6" Text="Left Screen in practice"/>
+                            <TextBlock Grid.Row="6" Text="Left Screen in qualy"/>
                             <ComboBox Grid.Row="6" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
-                                SelectedValuePath="Tag" SelectedValue="{Binding LeftPracticeScreen}">
-                                <ComboBoxItem Tag="0" IsSelected="True">None</ComboBoxItem>
-                                <ComboBoxItem Tag="0">Time1</ComboBoxItem>
-                                <ComboBoxItem Tag="1">Time2</ComboBoxItem>
-                                <ComboBoxItem Tag="2">Time3</ComboBoxItem>
-                                <ComboBoxItem Tag="3">Qualy</ComboBoxItem>
-                                <ComboBoxItem Tag="4">Race1</ComboBoxItem>
-                                <ComboBoxItem Tag="5">Race2</ComboBoxItem>
-                                <ComboBoxItem Tag="6">Race3</ComboBoxItem>
-                                <ComboBoxItem Tag="7">Practice1</ComboBoxItem>
-                                <ComboBoxItem Tag="8">Practice2</ComboBoxItem>
-                            </ComboBox>
-
-                                <TextBlock Grid.Row="7" Text="Right Screen in practice"/>
-                            <ComboBox Grid.Row="7" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
-                                    SelectedValuePath="Tag" SelectedValue="{Binding RightPracticeScreen}">
-                                <ComboBoxItem Tag="0" IsSelected="True">None</ComboBoxItem>
-                                <ComboBoxItem Tag="0">Stint1</ComboBoxItem>
-                                <ComboBoxItem Tag="1">Stint2</ComboBoxItem>
-                                <ComboBoxItem Tag="2">Qualy1</ComboBoxItem>
-                                <ComboBoxItem Tag="3">Qualy2</ComboBoxItem>
-                                <ComboBoxItem Tag="4">Race1</ComboBoxItem>
-                                <ComboBoxItem Tag="5">Race2</ComboBoxItem>
-                                <ComboBoxItem Tag="6">Race3</ComboBoxItem>
-                                <ComboBoxItem Tag="7">Track</ComboBoxItem>
-                            </ComboBox>
-
-                            <TextBlock Grid.Row="8" Text="Left Screen in qualy"/>
-                            <ComboBox Grid.Row="8" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
                         SelectedValuePath="Tag" SelectedValue="{Binding LeftQualyScreen}">
-                                <ComboBoxItem Tag="0" IsSelected="True">None</ComboBoxItem>
-                                <ComboBoxItem Tag="0">Time1</ComboBoxItem>
-                                <ComboBoxItem Tag="1">Time2</ComboBoxItem>
-                                <ComboBoxItem Tag="2">Time3</ComboBoxItem>
-                                <ComboBoxItem Tag="3">Qualy</ComboBoxItem>
-                                <ComboBoxItem Tag="4">Race1</ComboBoxItem>
-                                <ComboBoxItem Tag="5">Race2</ComboBoxItem>
-                                <ComboBoxItem Tag="6">Race3</ComboBoxItem>
-                                <ComboBoxItem Tag="7">Practice1</ComboBoxItem>
-                                <ComboBoxItem Tag="8">Practice2</ComboBoxItem>
+                                <ComboBoxItem Tag="1" IsSelected="True">Time1</ComboBoxItem>
+                                <ComboBoxItem Tag="2">Time2</ComboBoxItem>
+                                <ComboBoxItem Tag="3">Time3</ComboBoxItem>
+                                <ComboBoxItem Tag="4">Qualy</ComboBoxItem>
+                                <ComboBoxItem Tag="5">Race1</ComboBoxItem>
+                                <ComboBoxItem Tag="6">Race2</ComboBoxItem>
+                                <ComboBoxItem Tag="7">Race3</ComboBoxItem>
+                                <ComboBoxItem Tag="8">Practice1</ComboBoxItem>
+                                <ComboBoxItem Tag="9">Practice2</ComboBoxItem>
                             </ComboBox>
 
-                            <TextBlock Grid.Row="9" Text="Right Screen in qualy"/>
-                            <ComboBox Grid.Row="9" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
+                            <TextBlock Grid.Row="7" Text="Right Screen in qualy"/>
+                            <ComboBox Grid.Row="7" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
                             SelectedValuePath="Tag" SelectedValue="{Binding RightQualyScreen}">
-                                <ComboBoxItem Tag="0" IsSelected="True">None</ComboBoxItem>
-                                <ComboBoxItem Tag="0">Stint1</ComboBoxItem>
-                                <ComboBoxItem Tag="1">Stint2</ComboBoxItem>
-                                <ComboBoxItem Tag="2">Qualy1</ComboBoxItem>
-                                <ComboBoxItem Tag="3">Qualy2</ComboBoxItem>
-                                <ComboBoxItem Tag="4">Race1</ComboBoxItem>
-                                <ComboBoxItem Tag="5">Race2</ComboBoxItem>
-                                <ComboBoxItem Tag="6">Race3</ComboBoxItem>
-                                <ComboBoxItem Tag="7">Track</ComboBoxItem>
+                                <ComboBoxItem Tag="1" IsSelected="True">Stint1</ComboBoxItem>
+                                <ComboBoxItem Tag="2">Stint2</ComboBoxItem>
+                                <ComboBoxItem Tag="3">Qualy1</ComboBoxItem>
+                                <ComboBoxItem Tag="4">Qualy2</ComboBoxItem>
+                                <ComboBoxItem Tag="5">Race1</ComboBoxItem>
+                                <ComboBoxItem Tag="6">Race2</ComboBoxItem>
+                                <ComboBoxItem Tag="7">Race3</ComboBoxItem>
+                                <ComboBoxItem Tag="8">Track</ComboBoxItem>
                             </ComboBox>
 
-                            <TextBlock Grid.Row="10" Text="Left Screen in race"/>
-                            <ComboBox Grid.Row="10" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
+                            <TextBlock Grid.Row="8" Text="Left Screen in race"/>
+                            <ComboBox Grid.Row="8" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
                         SelectedValuePath="Tag" SelectedValue="{Binding LeftRaceScreen}">
-                                <ComboBoxItem Tag="0" IsSelected="True">None</ComboBoxItem>
-                                <ComboBoxItem Tag="0">Time1</ComboBoxItem>
-                                <ComboBoxItem Tag="1">Time2</ComboBoxItem>
-                                <ComboBoxItem Tag="2">Time3</ComboBoxItem>
-                                <ComboBoxItem Tag="3">Qualy</ComboBoxItem>
-                                <ComboBoxItem Tag="4">Race1</ComboBoxItem>
-                                <ComboBoxItem Tag="5">Race2</ComboBoxItem>
-                                <ComboBoxItem Tag="6">Race3</ComboBoxItem>
-                                <ComboBoxItem Tag="7">Practice1</ComboBoxItem>
-                                <ComboBoxItem Tag="8">Practice2</ComboBoxItem>
+                                <ComboBoxItem Tag="1" IsSelected="True">Time1</ComboBoxItem>
+                                <ComboBoxItem Tag="2">Time2</ComboBoxItem>
+                                <ComboBoxItem Tag="3">Time3</ComboBoxItem>
+                                <ComboBoxItem Tag="4">Qualy</ComboBoxItem>
+                                <ComboBoxItem Tag="5">Race1</ComboBoxItem>
+                                <ComboBoxItem Tag="6">Race2</ComboBoxItem>
+                                <ComboBoxItem Tag="7">Race3</ComboBoxItem>
+                                <ComboBoxItem Tag="8">Practice1</ComboBoxItem>
+                                <ComboBoxItem Tag="9">Practice2</ComboBoxItem>
                             </ComboBox>
 
-                            <TextBlock Grid.Row="11" Text="Right Screen in race"/>
-                            <ComboBox Grid.Row="11" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
+                            <TextBlock Grid.Row="9" Text="Right Screen in race"/>
+                            <ComboBox Grid.Row="9" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
                             SelectedValuePath="Tag" SelectedValue="{Binding RightRaceScreen}">
-                                <ComboBoxItem Tag="0" IsSelected="True">None</ComboBoxItem>
-                                <ComboBoxItem Tag="0">Stint1</ComboBoxItem>
-                                <ComboBoxItem Tag="1">Stint2</ComboBoxItem>
-                                <ComboBoxItem Tag="2">Qualy1</ComboBoxItem>
-                                <ComboBoxItem Tag="3">Qualy2</ComboBoxItem>
-                                <ComboBoxItem Tag="4">Race1</ComboBoxItem>
-                                <ComboBoxItem Tag="5">Race2</ComboBoxItem>
-                                <ComboBoxItem Tag="6">Race3</ComboBoxItem>
-                                <ComboBoxItem Tag="7">Track</ComboBoxItem>
+                                <ComboBoxItem Tag="1" IsSelected="True">Stint1</ComboBoxItem>
+                                <ComboBoxItem Tag="2">Stint2</ComboBoxItem>
+                                <ComboBoxItem Tag="3">Qualy1</ComboBoxItem>
+                                <ComboBoxItem Tag="4">Qualy2</ComboBoxItem>
+                                <ComboBoxItem Tag="5">Race1</ComboBoxItem>
+                                <ComboBoxItem Tag="6">Race2</ComboBoxItem>
+                                <ComboBoxItem Tag="7">Race3</ComboBoxItem>
+                                <ComboBoxItem Tag="8">Track</ComboBoxItem>
                             </ComboBox>
 
                                 </Grid>

--- a/SettingsControl.xaml
+++ b/SettingsControl.xaml
@@ -390,7 +390,13 @@
                                     <RowDefinition Height="1*" MinHeight="30"/>
                                     <RowDefinition Height="1*" MinHeight="30"/>
                                     <RowDefinition Height="1*" MinHeight="30"/>
-                                </Grid.RowDefinitions>
+                                    <RowDefinition Height="1*" MinHeight="30"/>
+                                    <RowDefinition Height="1*" MinHeight="30"/>
+                                    <RowDefinition Height="1*" MinHeight="30"/>
+                                    <RowDefinition Height="1*" MinHeight="30"/>
+                                    <RowDefinition Height="1*" MinHeight="30"/>
+                                    <RowDefinition Height="1*" MinHeight="30"/>
+                                    </Grid.RowDefinitions>
 
                             <TextBlock Grid.Row="1" 
                                 Text="Show Map instead of gear"    HorizontalAlignment="Left"
@@ -459,7 +465,95 @@
                                 <ComboBoxItem Tag="7">Race3</ComboBoxItem>
                                 <ComboBoxItem Tag="8">Track</ComboBoxItem>                                
                             </ComboBox>
-                            </Grid>
+
+                            <TextBlock Grid.Row="6" Text="Left Screen in practice"/>
+                            <ComboBox Grid.Row="6" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
+                                SelectedValuePath="Tag" SelectedValue="{Binding LeftPracticeScreen}">
+                                <ComboBoxItem Tag="0" IsSelected="True">None</ComboBoxItem>
+                                <ComboBoxItem Tag="0">Time1</ComboBoxItem>
+                                <ComboBoxItem Tag="1">Time2</ComboBoxItem>
+                                <ComboBoxItem Tag="2">Time3</ComboBoxItem>
+                                <ComboBoxItem Tag="3">Qualy</ComboBoxItem>
+                                <ComboBoxItem Tag="4">Race1</ComboBoxItem>
+                                <ComboBoxItem Tag="5">Race2</ComboBoxItem>
+                                <ComboBoxItem Tag="6">Race3</ComboBoxItem>
+                                <ComboBoxItem Tag="7">Practice1</ComboBoxItem>
+                                <ComboBoxItem Tag="8">Practice2</ComboBoxItem>
+                            </ComboBox>
+
+                                <TextBlock Grid.Row="7" Text="Right Screen in practice"/>
+                            <ComboBox Grid.Row="7" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
+                                    SelectedValuePath="Tag" SelectedValue="{Binding RightPracticeScreen}">
+                                <ComboBoxItem Tag="0" IsSelected="True">None</ComboBoxItem>
+                                <ComboBoxItem Tag="0">Stint1</ComboBoxItem>
+                                <ComboBoxItem Tag="1">Stint2</ComboBoxItem>
+                                <ComboBoxItem Tag="2">Qualy1</ComboBoxItem>
+                                <ComboBoxItem Tag="3">Qualy2</ComboBoxItem>
+                                <ComboBoxItem Tag="4">Race1</ComboBoxItem>
+                                <ComboBoxItem Tag="5">Race2</ComboBoxItem>
+                                <ComboBoxItem Tag="6">Race3</ComboBoxItem>
+                                <ComboBoxItem Tag="7">Track</ComboBoxItem>
+                            </ComboBox>
+
+                            <TextBlock Grid.Row="8" Text="Left Screen in qualy"/>
+                            <ComboBox Grid.Row="8" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
+                        SelectedValuePath="Tag" SelectedValue="{Binding LeftQualyScreen}">
+                                <ComboBoxItem Tag="0" IsSelected="True">None</ComboBoxItem>
+                                <ComboBoxItem Tag="0">Time1</ComboBoxItem>
+                                <ComboBoxItem Tag="1">Time2</ComboBoxItem>
+                                <ComboBoxItem Tag="2">Time3</ComboBoxItem>
+                                <ComboBoxItem Tag="3">Qualy</ComboBoxItem>
+                                <ComboBoxItem Tag="4">Race1</ComboBoxItem>
+                                <ComboBoxItem Tag="5">Race2</ComboBoxItem>
+                                <ComboBoxItem Tag="6">Race3</ComboBoxItem>
+                                <ComboBoxItem Tag="7">Practice1</ComboBoxItem>
+                                <ComboBoxItem Tag="8">Practice2</ComboBoxItem>
+                            </ComboBox>
+
+                            <TextBlock Grid.Row="9" Text="Right Screen in qualy"/>
+                            <ComboBox Grid.Row="9" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
+                            SelectedValuePath="Tag" SelectedValue="{Binding RightQualyScreen}">
+                                <ComboBoxItem Tag="0" IsSelected="True">None</ComboBoxItem>
+                                <ComboBoxItem Tag="0">Stint1</ComboBoxItem>
+                                <ComboBoxItem Tag="1">Stint2</ComboBoxItem>
+                                <ComboBoxItem Tag="2">Qualy1</ComboBoxItem>
+                                <ComboBoxItem Tag="3">Qualy2</ComboBoxItem>
+                                <ComboBoxItem Tag="4">Race1</ComboBoxItem>
+                                <ComboBoxItem Tag="5">Race2</ComboBoxItem>
+                                <ComboBoxItem Tag="6">Race3</ComboBoxItem>
+                                <ComboBoxItem Tag="7">Track</ComboBoxItem>
+                            </ComboBox>
+
+                            <TextBlock Grid.Row="10" Text="Left Screen in race"/>
+                            <ComboBox Grid.Row="10" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
+                        SelectedValuePath="Tag" SelectedValue="{Binding LeftRaceScreen}">
+                                <ComboBoxItem Tag="0" IsSelected="True">None</ComboBoxItem>
+                                <ComboBoxItem Tag="0">Time1</ComboBoxItem>
+                                <ComboBoxItem Tag="1">Time2</ComboBoxItem>
+                                <ComboBoxItem Tag="2">Time3</ComboBoxItem>
+                                <ComboBoxItem Tag="3">Qualy</ComboBoxItem>
+                                <ComboBoxItem Tag="4">Race1</ComboBoxItem>
+                                <ComboBoxItem Tag="5">Race2</ComboBoxItem>
+                                <ComboBoxItem Tag="6">Race3</ComboBoxItem>
+                                <ComboBoxItem Tag="7">Practice1</ComboBoxItem>
+                                <ComboBoxItem Tag="8">Practice2</ComboBoxItem>
+                            </ComboBox>
+
+                            <TextBlock Grid.Row="11" Text="Right Screen in race"/>
+                            <ComboBox Grid.Row="11" Grid.Column="1"  MaxWidth="200" HorizontalAlignment="Left" 
+                            SelectedValuePath="Tag" SelectedValue="{Binding RightRaceScreen}">
+                                <ComboBoxItem Tag="0" IsSelected="True">None</ComboBoxItem>
+                                <ComboBoxItem Tag="0">Stint1</ComboBoxItem>
+                                <ComboBoxItem Tag="1">Stint2</ComboBoxItem>
+                                <ComboBoxItem Tag="2">Qualy1</ComboBoxItem>
+                                <ComboBoxItem Tag="3">Qualy2</ComboBoxItem>
+                                <ComboBoxItem Tag="4">Race1</ComboBoxItem>
+                                <ComboBoxItem Tag="5">Race2</ComboBoxItem>
+                                <ComboBoxItem Tag="6">Race3</ComboBoxItem>
+                                <ComboBoxItem Tag="7">Track</ComboBoxItem>
+                            </ComboBox>
+
+                                </Grid>
                   
                             <TextBlock>Controls</TextBlock>
                             <ui:ControlsEditor FriendlyName="Left Screen > Next Page" ActionName="DahlDesign.Controls.Dashboard.LeftScreen.Next" HorizontalAlignment="Left" Width="750"/>

--- a/iRacing/iRacing.cs
+++ b/iRacing/iRacing.cs
@@ -117,7 +117,7 @@ namespace DahlDesign.Plugin.iRacing
 
         string carModelHolder = "";
         string trackHolder = "";
-        string sessionHolder = "";
+        public string sessionHolder { get; set; } = "";
 
         List<double?> carAheadGap = new List<double?> { };
         List<double?> carAheadRaceGap = new List<double?> { };


### PR DESCRIPTION
Added the framework for this feature, but not 100% successful. 

![image](https://user-images.githubusercontent.com/40788634/203441842-9c7bd7a6-f434-48de-a1ed-a2742f4e52dd.png)

I was getting the dashboard 1 step ahead of the one selected dashboard in the plugin menu. So if Race setup was Race1/Race1, I' get Race2/Race2. I thought it might be the screen IDs starting with 0, but shifting everything own by one didnt make any difference in the outcome, which in itself was kind of confusing. Any idea what might be going wrong?