### PR TITLE
removed 60FPs throtteling and performance counters

### DIFF
--- a/DataPlugin.cs
+++ b/DataPlugin.cs
@@ -21,25 +21,12 @@ namespace DahlDesign.Plugin
         public Categories.Dashboard Dashboard;
         public Categories.DDC DDC;
         public iRacing.Data iRacing;
-        const long TicksFor60Fps = 10000000 / 60;
-        internal bool UpdateAt60Fps;
-        internal long LastRan60Fps;
         public int counter = 0;
         public ImageSource PictureIcon => this.ToIcon(Properties.Resources.Dahl_icon);
         public string LeftMenuTitle => "Dahl Design";
         public bool gameRunning;
         public string gameName;
         public GameData gameData;
-
-#if DEBUG
-        public double performanceSkippedFrames = 0;
-        /// <summary>
-        /// List of 'ticks' needed for each frame.
-        /// One tick is 100ns. There are 10000 ticks in a millisecond
-        /// </summary>
-        public long[] performanceFrames = new long[60];
-        public long performanceTimerStart = 0;
-#endif
 
         /// <summary>
         /// Called once after plugins startup
@@ -56,13 +43,6 @@ namespace DahlDesign.Plugin
             Dashboard = new Categories.Dashboard(this);
             DDC = new Categories.DDC(this);
             iRacing = new iRacing.Data(this);
-
-#if DEBUG
-            this.AttachDelegate("Performance.SkippedFrames", () => performanceSkippedFrames);
-            this.AttachDelegate("Performance.FramesSum", () => performanceFrames.Sum());
-            this.AttachDelegate("Performance.Frames", () => String.Join("\r\n ", performanceFrames
-                  .Select((d, i) => i + "=" + d).ToArray()));
-#endif
         }
 
         public void DataUpdate(PluginManager pluginManager, ref GameData data)
@@ -73,38 +53,19 @@ namespace DahlDesign.Plugin
 
             //FRAME COUNTER FOR CPU SAVING
             //Counters used: 1,2,3,4,5,6,7,8,9,10,11,14,15,17,20,22,24,25,27,30,33,35,36,38,39,40,43,45,47,50,51,52,53,54,55,59  
-            long nowTicks = DateTime.Now.Ticks;
-            UpdateAt60Fps = nowTicks - LastRan60Fps >= TicksFor60Fps;
 
-            if (UpdateAt60Fps)
+            counter++;
+
+            //Resetting counter
+            if (counter > 59)
             {
-                LastRan60Fps = DateTime.Now.Ticks;
-                counter++;
-#if DEBUG
-                performanceTimerStart = nowTicks;
-#endif
-                //Resetting counter
-                if (counter > 59)
-                {
-                    counter = 0;
-                }
-            } else
-            {
-#if DEBUG
-                performanceSkippedFrames++;
-#endif
-                return;
+                counter = 0;
             }
 
             Dashboard.DataUpdate();
             DDC.DataUpdate();
             iRacing.DataUpdate();
             iRacing.DataUpdateIdle();
-
-#if DEBUG
-            if (DateTime.Now.Ticks - performanceTimerStart > 0)
-                performanceFrames[counter] = (DateTime.Now.Ticks - performanceTimerStart);
-#endif
         }
 
         public void End(PluginManager pluginManager)


### PR DESCRIPTION
Removed 60FPS calculation due to inaccuracy.
Removed performance counters, quite useless and we have them already directly in SimHub