### PR TITLE
Add SF23 to car list

### DIFF
--- a/iRacing/CarInfos.cs
+++ b/iRacing/CarInfos.cs
@@ -32,6 +32,7 @@ namespace DahlDesign.Plugin.iRacing
             carInfo.Add(new Cars("Supercars Holden ZB Commodore", false, false, false, false, -1, false, false, false, -1, -1, -1, false, false, "Single", "Supercar", 7470, 7470, 7470, 7480, 7480, 0, 0, 7490, 1205, 29.5, 29.0, 29.6, 33.0, 1, 50, 1, 100, true, 0, 1.15, 0.7, 0.7, 0.9, 2.36, false, 0, 0, 6.7, 0.9, CrewType.All, true, true, AnimationType.Supercar, 0.35));
             carInfo.Add(new Cars("iRacing Formula IR-04", false, false, false, false, -1, false, false, false, -1, -1, -1, false, false, "Single", "BiasOnly", 7150, 7100, 7090, 7090, 7090, 0, 0, 7270, 1200, 33.8, 24.5, 25, 37, 1, 100, 1, 100, false, 0, 0.9, 1, 1, 0.9, 6.25, false, 0, 0, 6.11, 0, CrewType.All, true, false, AnimationType.F4, 0.35));
             carInfo.Add(new Cars("Toyota GR86", false, false, false, false, 0, true, true, false, 0, -1, -1, false, false, "Single", "TC/ABS", 7400, 7370, 7350, 7330, 7330, 0, 0, 7465, 1000, 56.0, 48.0, 48.0, 62.0, 1, 100, 1, 100, false, 0, 0.8, 0.83, 0.95, 0.5, 1.65, false, 0, 0, 14.5, -6.5, CrewType.SingleTyre, true, true, AnimationType.ToyotaGR86, 0.15));
+            carInfo.Add(new Cars("Super Formula SF23 - Toyota", false, false, false, false, -1, false, false, false, -1, -1, -1, false, true, "Single", "BiasOnly", 7830, 7870, 7910, 8150, 8150, 8150, 0, 9325, 2800, 71.0, 0, 0, 0, 1, 70, 2, 80, true, 25, 0, 0, 0, 0, 8.5, false, 0, 0, 6, 1.5, CrewType.All, true, false, AnimationType.FormulaRenault, 0.6));
         }        
     }
 }


### PR DESCRIPTION
For now, this at least gets us shift points and the `biasOnly` dash type.

iRacing did not include telemetry specific to this car in the latest patch today. Which means we still don't have the real `OTTime` and `ReTime` and P2P remaining seconds.

Once we do have that, I intend to build a specific page for this car in the gear widget. And also add flashing warnings when the remaining length of the race exceeds the p2p seconds remaining. That way you get a nice flash on the screen that tells you, "USE REMAINING P2P" as well as cool down notifications.